### PR TITLE
Tmp Patch: Override swipe threshold

### DIFF
--- a/src/page/Shard.tsx
+++ b/src/page/Shard.tsx
@@ -62,7 +62,7 @@ export default function Home() {
     onSwipedRight: prevDay,
     preventScrollOnSwipe: true,
     trackMouse: true,
-    delta: 50,
+    delta: 100,
   });
 
   return (

--- a/src/page/Shard.tsx
+++ b/src/page/Shard.tsx
@@ -62,6 +62,7 @@ export default function Home() {
     onSwipedRight: prevDay,
     preventScrollOnSwipe: true,
     trackMouse: true,
+    delta: 50,
   });
 
   return (


### PR DESCRIPTION
Without overriding the swipe threshold is 10px, which can be accidentally triggered. Increase it to 50px