### PR TITLE
fix: no-shard day English phrasing

### DIFF
--- a/src/components/Date.tsx
+++ b/src/components/Date.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import { DateTime } from 'luxon';
 import { useNow } from '../context/Now';
 import { useSettings } from '../context/Settings';
@@ -18,14 +17,14 @@ export default function Date({ date, local, short, describeClose, hideWeekday, h
   const now = local ? useNow().local : useNow().application;
   date = (local ? date?.toLocal() : date?.setZone('America/Los_Angeles')) ?? now;
   const howClose = Math.ceil(date.diff(now, 'days').days);
-  if (describeClose && howClose <= 1) {
+  if (describeClose && howClose <= 1 && howClose >= -1) {
     return (
       <span className='Date'>
         {
           {
-            '-1': ', Yesterday',
-            '0': ', Today',
-            '1': ', Tomorrow',
+            '-1': ' Yesterday',
+            '0': ' Today',
+            '1': ' Tomorrow',
           }[howClose.toString()]
         }
       </span>
@@ -40,7 +39,7 @@ export default function Date({ date, local, short, describeClose, hideWeekday, h
   ].join('');
   return (
     <>
-      {describeClose && <span>, on </span>}
+      {describeClose && <span> on </span>}
       <span className='Date'>{date.toFormat(format)}</span>
     </>
   );

--- a/src/sections/Shard/Info.tsx
+++ b/src/sections/Shard/Info.tsx
@@ -6,7 +6,7 @@ import { getShardInfo, ShardInfo } from '../../shardPredictor';
 interface ShardInfoDisplayProps {
   info?: ShardInfo;
   now?: DateTime;
-  verbsTense?: 'past' | 'present' | 'future';
+  verbsTense: 'past' | 'present' | 'future';
 }
 
 export default function ShardInfoDisplay({ info, now, verbsTense }: ShardInfoDisplayProps) {
@@ -17,9 +17,8 @@ export default function ShardInfoDisplay({ info, now, verbsTense }: ShardInfoDis
   if (!haveShard) {
     return (
       <div id='shardInfo' className='glass'>
-        <span>There is </span>
-        <span className='Emphasized'>No Shard </span>
-        <span>on </span>
+        <span>There {verbsTense === 'future' ? 'will be' : verbsTense === 'past' ? 'was' : 'is'} </span>
+        <span className='Emphasized'>No Shard</span>
         <Date date={date} describeClose />
       </div>
     );
@@ -27,9 +26,7 @@ export default function ShardInfoDisplay({ info, now, verbsTense }: ShardInfoDis
     return (
       <div id='shardInfo' className='glass'>
         <span>
-          <span>
-            There {verbsTense && verbsTense !== 'future' ? (verbsTense === 'past' ? 'was' : 'is') : 'will be'}{' '}
-          </span>
+          <span>There {verbsTense === 'future' ? 'will be' : verbsTense === 'past' ? 'was' : 'is'} a </span>
           <span className={`${color} Emphasized`}>{color} Shard </span>
           <span> in </span>
         </span>


### PR DESCRIPTION
- `howClose <= 1` made every instance in the past have no date.
- `verbsTense` seemed to always be defined. I removed its optional typing. It can be made optional again in the future when it needs to be.
- No tense in no-shard days.